### PR TITLE
Feature/lint warn steps too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@
 # JetBrains IDE metadata folders
 /.idea
 
+# Mac metadata directories
+.DS_Store
+
 Gemfile.lock

--- a/lib/cuke_linter.rb
+++ b/lib/cuke_linter.rb
@@ -7,16 +7,18 @@ require 'cuke_linter/linters/example_without_name_linter'
 require 'cuke_linter/linters/feature_without_scenarios_linter'
 require 'cuke_linter/linters/outline_with_single_example_row_linter'
 require 'cuke_linter/linters/test_with_too_many_steps_linter'
+require 'cuke_linter/linters/test_step_with_too_many_characters_linter'
 
 
 # The top level namespace used by this gem
 
 module CukeLinter
 
-  @original_linters = { 'FeatureWithoutScenariosLinter'     => FeatureWithoutScenariosLinter.new,
-                        'ExampleWithoutNameLinter'          => ExampleWithoutNameLinter.new,
-                        'OutlineWithSingleExampleRowLinter' => OutlineWithSingleExampleRowLinter.new,
-                        'TestWithTooManyStepsLinter'        => TestWithTooManyStepsLinter.new }
+  @original_linters = { 'FeatureWithoutScenariosLinter'       => FeatureWithoutScenariosLinter.new,
+                        'ExampleWithoutNameLinter'            => ExampleWithoutNameLinter.new,
+                        'OutlineWithSingleExampleRowLinter'   => OutlineWithSingleExampleRowLinter.new,
+                        'TestWithTooManyStepsLinter'          => TestWithTooManyStepsLinter.new,
+                        'TestStepWithTooManyCharactersLinter' => TestStepWithTooManyCharactersLinter.new }
 
   # Configures linters based on the given options
   def self.load_configuration(config_file_path: nil, config: nil)

--- a/lib/cuke_linter/linters/test_step_with_too_many_characters_linter.rb
+++ b/lib/cuke_linter/linters/test_step_with_too_many_characters_linter.rb
@@ -1,0 +1,34 @@
+module CukeLinter
+
+  # A linter that detects scenarios and outlines that have too many steps
+
+  class TestStepWithTooManyCharactersLinter < Linter
+  
+    DEFAULT_STEP_LENGTH_THRESHOLD = 120
+
+    # Changes the linting settings on the linter using the provided configuration
+    def configure(options)
+      @step_length_threshold = options['StepLengthThreshold'] if options['StepLengthThreshold']
+    end
+
+    # The rule used to determine if a model has a problem
+    def rule(model)
+      return false unless model.is_a?(CukeModeler::Step)
+        
+      @linted_step_length = model.text&.length || 0
+
+      @linted_step_length > step_length_threshold
+    end
+
+    # The message used to describe the problem that has been found
+    def message
+      "Step is too long. #{@linted_step_length} characters found (max #{step_length_threshold})"
+    end
+
+    # The maximum length allowable of a step
+    def step_length_threshold
+      @step_length_threshold || DEFAULT_STEP_LENGTH_THRESHOLD
+    end
+
+  end
+end

--- a/testing/cucumber/features/linters/default_linters.feature
+++ b/testing/cucumber/features/linters/default_linters.feature
@@ -8,10 +8,11 @@ Feature: Default Linters
   Scenario: Using the default linters
     Given no other linters have been registered or unregistered
     Then the following linters are registered by default
-      | ExampleWithoutNameLinter          |
-      | FeatureWithoutScenariosLinter     |
-      | OutlineWithSingleExampleRowLinter |
-      | TestWithTooManyStepsLinter        |
+      | ExampleWithoutNameLinter            |
+      | FeatureWithoutScenariosLinter       |
+      | OutlineWithSingleExampleRowLinter   |
+      | TestWithTooManyStepsLinter          |
+      | TestStepWithTooManyCharactersLinter |
 
   Scenario: Registering new linters
     Given no linters are currently registered

--- a/testing/cucumber/features/linters/step_too_long.feature
+++ b/testing/cucumber/features/linters/step_too_long.feature
@@ -1,0 +1,43 @@
+Feature: Test step with too many characters
+
+  As a reader of documentation
+  I want test steps not to be unduly long
+  So that I can easily understand its purpose
+
+
+  Scenario: Linting
+
+    Given a linter for test steps with too many characters
+    And the following feature:
+      """
+      Feature:
+
+        Scenario:
+          * tea exists and teapots exist and so do cups and saucers and there might be milk in the milk jug together with sugar cubes
+      """
+    When it is linted
+    Then an error is reported
+      | linter                              | problem                                          | location         |
+      | TestStepWithTooManyCharactersLinter | Step is too long. 121 characters found (max 120) | <path_to_file>:4 |
+
+
+  Scenario: Configuration of step count threshold
+  
+    Given a linter for test steps with too many characters has been registered
+    And the following configuration file:
+      """
+      TestStepWithTooManyCharactersLinter:
+        StepLengthThreshold: 55
+      """
+    And the following feature:
+      """
+      Feature:
+
+        Scenario:
+          Given that a rose by any other name would still smell as sweet
+      """
+    When the configuration file is loaded
+    And the feature is linted
+    Then an error is reported
+      | linter                     | problem                                        | location         |
+      | TestStepWithTooManyCharactersLinter | Step is too long. 56 characters found (max 55) | <path_to_file>:4 |

--- a/testing/cucumber/step_definitions/setup_steps.rb
+++ b/testing/cucumber/step_definitions/setup_steps.rb
@@ -41,8 +41,16 @@ Given(/^a linter for tests with too many steps$/) do
   @linter = CukeLinter::TestWithTooManyStepsLinter.new
 end
 
+Given("a linter for test steps with too many characters") do
+  @linter = CukeLinter::TestStepWithTooManyCharactersLinter.new
+end
+
 Given(/^a linter for tests with too many steps has been registered$/) do
   CukeLinter.register_linter(linter: CukeLinter::TestWithTooManyStepsLinter.new, name: 'TestWithTooManyStepsLinter')
+end
+
+Given(/^a linter for test steps with too many characters has been registered$/) do
+  CukeLinter.register_linter(linter: CukeLinter::TestStepWithTooManyCharactersLinter.new, name: 'TestStepWithTooManyCharactersLinter')
 end
 
 Given(/^the following configuration file(?: "([^"]*)")?:$/) do |file_name, text|


### PR DESCRIPTION
Simple linter warn when a step definition is too long. It is not including the gherkin keyword and I've picked 120 characters as the default max length fairly arbitrarily.