### PR TITLE
Add pylint-style formatter

### DIFF
--- a/lib/cuke_linter.rb
+++ b/lib/cuke_linter.rb
@@ -3,6 +3,7 @@ require 'cuke_modeler'
 
 require 'cuke_linter/version'
 require 'cuke_linter/formatters/pretty_formatter'
+require 'cuke_linter/formatters/pylint_formatter'
 require 'cuke_linter/linters/linter'
 require 'cuke_linter/linters/background_does_more_than_setup_linter'
 require 'cuke_linter/linters/element_with_common_tags_linter'

--- a/lib/cuke_linter/formatters/pylint_formatter.rb
+++ b/lib/cuke_linter/formatters/pylint_formatter.rb
@@ -1,0 +1,20 @@
+module CukeLinter
+  # Formats linting data into the PyLint format
+  # path/to/file:line:col: [Rule] Message
+  class Pylint8Formatter
+    # Formats the given linting data
+    def format(data)
+      ''.tap do |formatted_data|
+        data.each do |problem|
+          location = problem[:location].split(":")
+          # Linters at the very least don't specify column numbers, but for feature file wide errors
+          # there's no line numbers either. Pad the location out if we need to.
+          while location.length() < 3
+            location.insert(-1, "1")
+          end
+          formatted_data << "#{location.join(separator=':')}: [#{problem[:linter]}] #{problem[:problem]}\n"
+        end
+      end
+    end
+  end
+end

--- a/lib/cuke_linter/formatters/pylint_formatter.rb
+++ b/lib/cuke_linter/formatters/pylint_formatter.rb
@@ -1,7 +1,7 @@
 module CukeLinter
   # Formats linting data into the PyLint format
   # path/to/file:line:col: [Rule] Message
-  class Pylint8Formatter
+  class PylintFormatter
     # Formats the given linting data
     def format(data)
       ''.tap do |formatted_data|

--- a/lib/cuke_linter/formatters/pylint_formatter.rb
+++ b/lib/cuke_linter/formatters/pylint_formatter.rb
@@ -10,7 +10,7 @@ module CukeLinter
           # Linters at the very least don't specify column numbers, but for feature file wide errors
           # there's no line numbers either. Pad the location out if we need to.
           while location.length() < 3
-            location.insert(-1, "1")
+            location.insert(-1, "")
           end
           formatted_data << "#{location.join(separator=':')}: [#{problem[:linter]}] #{problem[:problem]}\n"
         end

--- a/testing/cucumber/features/formatters/pylint_formatter.feature
+++ b/testing/cucumber/features/formatters/pylint_formatter.feature
@@ -1,0 +1,19 @@
+Feature: Pylint formatter
+
+  The Pylint formatter is a formatter with a more easily machine-parseable output.
+
+  Scenario: Formatting linter data
+    Given the following linter data:
+      | linter name                      | problem             | location               |
+      | FeatureFileWithInvalidNameLinter | Invalid file name   | path/to/the-file       |
+      | FeatureWithoutDescriptionLinter  | No description      | path/to/the_file:1     |
+      | SomeOtherLinter                  | Some other problem  | path/to/the_file:33    |
+      | SomeOtherLinter                  | Problem with column | path/to/the_file:33:33 |
+    When it is formatted by the "pylint" formatter
+    Then the resulting output is the following:
+      """
+      path/to/the/file::: [FeatureFileWithInvalidNameLinter] Invalid file name
+      path/to/the_file:1:: [FeatureWithoutDescriptionLinter] No description
+      path/to/the_file:33:: [SomeOtherLinter] Some other problem
+      path/to/the_file:33:33: [SomeOtherLinter] Problem with column
+      """

--- a/testing/cucumber/features/formatters/pylint_formatter.feature
+++ b/testing/cucumber/features/formatters/pylint_formatter.feature
@@ -9,7 +9,7 @@ Feature: Pylint formatter
       | FeatureWithoutDescriptionLinter  | No description      | path/to/the_file:1     |
       | SomeOtherLinter                  | Some other problem  | path/to/the_file:33    |
       | SomeOtherLinter                  | Problem with column | path/to/the_file:33:33 |
-    When it is formatted by the "pylint" formatter
+    When it is formatted by the "Pylint" formatter
     Then the resulting output is the following:
       """
       path/to/the/file::: [FeatureFileWithInvalidNameLinter] Invalid file name


### PR DESCRIPTION
This formatter produces output that's a bit easier to parse programmatically, e.g. for use in VSCode's problem matchers or CI reports.

`path/to/file:linenum:colnum: [Linter] Problem description`